### PR TITLE
Updating the last_dewarp correctly.

### DIFF
--- a/ModInterface/ThaumCraft/ItemWarpProofer.java
+++ b/ModInterface/ThaumCraft/ItemWarpProofer.java
@@ -43,9 +43,9 @@ public class ItemWarpProofer extends ItemChromaTool {
 				is.stackTagCompound.setString(PLAYER_TAG, ep.getCommandSenderName());
 			}
 			if (world.getTotalWorldTime()-e.getEntityData().getLong(ACTIVITY_TAG) >= 240) {
+				e.getEntityData().setLong(ACTIVITY_TAG, world.getTotalWorldTime());
 				ReikaThaumHelper.removeWarp(ep, 1);
 			}
-			e.getEntityData().setLong(ACTIVITY_TAG, world.getTotalWorldTime());
 		}
 	}
 


### PR DESCRIPTION
You should only update the last_dewarp tag on the player after actually performing the dewarp.  Otherwise you have to keep the item out of your inventory for 4 minutes.